### PR TITLE
Fixed dependencies for PE 2016.5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class pe_slack_bot (
   $hostpubkey  = $settings::hostcert,
   $cakey       = $settings::localcacert,
 ) {
-  $gemdeps = ['activesupport','puma','sinatra','dotenv','puppetdb-ruby','slack-ruby-bot','bundler','foreman','rspec','json_pure','rack-test']
+  $gemdeps = ['puma','sinatra','dotenv','puppetdb-ruby','slack-ruby-bot','foreman','rspec','json_pure','rack-test']
   
   package { 'gcc-c++':
     ensure   => latest,
@@ -17,6 +17,14 @@ class pe_slack_bot (
     before   => Vcsrepo['/opt/pe-slack-bot'],
     require  => Package['gcc-c++'],
   }
+
+  package { 'activesupport':
+    ensure   => '4.2.6',
+    provider => 'puppet_gem',
+    before   => Vcsrepo['/opt/pe-slack-bot'],
+    require  => Package['gcc-c++'],
+  }
+
 
   file { "${settings::confdir}/peslackbot.yaml":
     ensure  => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@ class pe_slack_bot (
   $cakey       = $settings::localcacert,
 ) {
   $gemdeps = ['puma','sinatra','dotenv','puppetdb-ruby','slack-ruby-bot','foreman','rspec','json_pure','rack-test']
-  
+
   package { 'gcc-c++':
     ensure   => latest,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ncorrare-pe_slack_bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "ncorrare",
   "summary": "A module to configure the pe-slack-bot for interacting with Puppet Orchestrator / PuppetDB",
   "license": "Apache-2.0",


### PR DESCRIPTION
2016.5 includes bundler and because of the Ruby version can't just use the latest active support. Gem is not smart enough to realise it, apparently.